### PR TITLE
Change namespace for kernel.php in sync with rest of the bundle

### DIFF
--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App;
+namespace Iaasen\Matrikkel;
 
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
 use Symfony\Component\HttpKernel\Kernel as BaseKernel;


### PR DESCRIPTION
fix for namespace warning when this bundle is autowired into the higher goods